### PR TITLE
fix: Resolve signature pad bug and on-load table generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Générateur de Fiche d'Heures
 
-[https://toastaspiring.github.io/app_declaration_heure/](https://toastaspiring.github.io/app_declaration_heure/)
-
 ## Aperçu du Projet
 
 Le Générateur de Fiche d'Heures est une application web monopage conçue pour simplifier la création, la gestion et l'exportation de fiches d'heures mensuelles. C'est un outil complet qui s'adresse aussi bien aux employés qu'aux employeurs, en automatisant les calculs et en offrant des fonctionnalités avancées telles que la sauvegarde de brouillons et les signatures numériques.
@@ -50,4 +48,3 @@ Le projet est intentionnellement simple et ne contient que deux fichiers princip
 
 -   `index.html` : Ce fichier contient la structure HTML de l'application, les styles CSS (via Tailwind) et les références aux bibliothèques JavaScript.
 -   `script.js` : Ce fichier contient toute la logique de l'application, y compris la génération du tableau, les calculs, la gestion du stockage local (brouillons, modèles, signatures) et la génération du PDF.
-

--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
                 </div>
             </div>
             <div class="mt-8 flex justify-end gap-4">
+                <button id="save-signatures-btn" class="bg-blue-600 text-white font-bold py-2 px-5 rounded-md hover:bg-blue-700">Sauvegarder</button>
                 <button id="close-signature-modal-btn" class="bg-gray-500 text-white font-bold py-2 px-5 rounded-md hover:bg-gray-600">Fermer</button>
             </div>
         </div>


### PR DESCRIPTION
This commit addresses user feedback on the application's behavior and fixes a critical bug.

1.  **Fix Signature Pad Drawing:**
    -   The signature pad initialization logic has been moved. It now runs only when the signature modal is opened, ensuring the canvas is visible and has the correct dimensions. This resolves the bug where users were unable to draw their signatures.
    -   The real-time `onEnd` saving has been removed. Signatures are now saved only when the user explicitly clicks the new "Sauvegarder" button in the modal.

2.  **Prevent Table Generation on Page Load:**
    -   The application no longer automatically generates the timesheet table when the page loads, even if a draft exists.
    -   The "Générer le tableau" button now correctly uses the existing draft data to populate the table, providing a more intentional user experience.